### PR TITLE
Fix in finding the SECTION_BEGIN bsc#1210908

### DIFF
--- a/libraries/bash/Core.rc
+++ b/libraries/bash/Core.rc
@@ -202,7 +202,7 @@ getSection() {
 	local SECTION_FOUND=0
 	if [[ -s $ARCH_FILE ]]
 	then
-		local SECTION_BEGIN=$(grep -nA1 '#==\[' $ARCH_FILE | grep "$SECTION_STRING" | cut -d\- -f1)
+		local SECTION_BEGIN=$(grep -nA1 '#==\[' $ARCH_FILE | grep "$SECTION_STRING" | cut -d\- -f1 | tail -1)
 		local SECTION_END=0
 		if [[ -n "$SECTION_BEGIN" ]]
 		then


### PR DESCRIPTION
There can be multiple lines that are found by the grep rule; therefore the variable SECTION_BEGIN would contain multiple line numbers and the test would fail

```bash
local SECTION_BEGIN=$(grep -nA1 '#==\[' $ARCH_FILE | grep "$SECTION_STRING" | cut -d\- -f1)
  local SECTION_END=0
  if [[ -n "$SECTION_BEGIN" ]]
  then
    for I in $(grep -n '#==\[' $ARCH_FILE | cut -d\: -f1)
    do
      if (( $I > $SECTION_BEGIN ))  # <--- this test fails
```
The tail selects only the last number